### PR TITLE
Additonal hooks

### DIFF
--- a/lua/autorun/server/sv_pvp_movespeed.lua
+++ b/lua/autorun/server/sv_pvp_movespeed.lua
@@ -55,7 +55,7 @@ local function setSpeed(ply, multiplier)
     ply:SetWalkSpeed(math.Clamp(baseWalkSpeed*multiplier,minWalkSpeed, baseWalkSpeed))
 end
 
-local function adjustMovementSpeed(ply) 
+local function adjustMovementSpeed(ply, wep) 
     if playerIsInBuild( ply ) then 
         setSpeed(ply, 1) 
         return
@@ -65,6 +65,9 @@ local function adjustMovementSpeed(ply)
     local wepCount = 0
     
     -- count weapons
+    if nonEffectedWeapons[wep:GetClass()] == nil then
+        wepCount =  wepCount+1
+    end
     for k, weapon in pairs(weapons) do
         if nonEffectedWeapons[weapon:GetClass()] == nil then
             wepCount =  wepCount+1
@@ -78,7 +81,7 @@ end
 -- Hook Functions --
 local function onEquipOrDrop( wep, ply )
     if not IsValid( ply ) then return end
-    adjustMovementSpeed( ply )
+    adjustMovementSpeed( ply, wep )
 end
 
 -- Hooks --

--- a/lua/autorun/server/sv_pvp_movespeed.lua
+++ b/lua/autorun/server/sv_pvp_movespeed.lua
@@ -53,8 +53,8 @@ local function setSpeed(ply, multiplier)
     -- set speed multiplier, 0 - 1
     local runSpeed = baseRunSpeed * multiplier
     local walkSpeed = baseWalkSpeed * multiplier
-    ply:SetRunSpeed( math.Clamp( runSpeed, minRunSpeed, baseRunSpeed ) )
-    ply:SetWalkSpeed( math.Clamp( walkSpeed, minWalkSpeed, baseWalkSpeed ) )
+    ply:SetRunSpeed( math.max( runSpeed, minRunSpeed ) )
+    ply:SetWalkSpeed( math.max( walkSpeed, minWalkSpeed ) )
 end
 
 local function adjustMovementSpeed( ply, wepNum ) 
@@ -72,7 +72,7 @@ local function adjustMovementSpeed( ply, wepNum )
             wepCount =  wepCount + 1
         end
     end
-    wepCount = math.max(wepCount + wepNum, 0)
+    wepCount = wepCount + wepNum
     
     local multiplier = movementMultiplier( wepCount ) 
     setSpeed(ply, multiplier)

--- a/lua/autorun/server/sv_pvp_movespeed.lua
+++ b/lua/autorun/server/sv_pvp_movespeed.lua
@@ -51,12 +51,12 @@ end
 
 local function setSpeed(ply, multiplier) 
     -- set speed multiplier, 0 - 1
-    ply:SetRunSpeed(math.Clamp(baseRunSpeed*multiplier,minRunSpeed, baseRunSpeed))
-    ply:SetWalkSpeed(math.Clamp(baseWalkSpeed*multiplier,minWalkSpeed, baseWalkSpeed))
+    ply:SetRunSpeed( math.Clamp( baseRunSpeed*multiplier, minRunSpeed, baseRunSpeed ) )
+    ply:SetWalkSpeed( math.Clamp( baseWalkSpeed*multiplier, minWalkSpeed, baseWalkSpeed ) )
 end
 
-local function adjustMovementSpeed(ply, wep) 
-    if playerIsInBuild( ply ) then 
+local function adjustMovementSpeed( ply, wepNum ) 
+    if playerIsInBuild( ply ) then
         setSpeed(ply, 1) 
         return
     end
@@ -65,28 +65,34 @@ local function adjustMovementSpeed(ply, wep)
     local wepCount = 0
     
     -- count weapons
-    if wep and nonEffectedWeapons[wep:GetClass()] == nil then
-        wepCount =  wepCount+1
-    end
-    for k, weapon in pairs(weapons) do
+    for _, weapon in pairs( weapons ) do
         if nonEffectedWeapons[weapon:GetClass()] == nil then
-            wepCount =  wepCount+1
+            wepCount =  wepCount + 1
         end
     end
+    wepCount = math.Clamp(wepCount + wepNum, 0, wepCount + wepNum)
     
-    local multiplier = movementMultiplier(wepCount) 
+    local multiplier = movementMultiplier( wepCount ) 
     setSpeed(ply, multiplier)
 end
 
 -- Hook Functions --
 local function onEquip( wep, ply )
     if not IsValid( ply ) then return end
-    adjustMovementSpeed( ply, wep )
+    wepNum = 0
+    if wep and nonEffectedWeapons[wep:GetClass()] == nil then
+        wepNum = 1
+    end
+    adjustMovementSpeed( ply, wepNum )
 end
 
 local function onDrop( ply, wep )
     if not IsValid( ply ) then return end
-    adjustMovementSpeed( ply, nil )
+    wepNum = 0
+    if wep and nonEffectedWeapons[wep:GetClass()] == nil then
+        wepNum = -1
+    end
+    adjustMovementSpeed( ply, wepNum )
 end
 
 -- Hooks --
@@ -95,4 +101,3 @@ hook.Add("WeaponEquip", generateCFCHook("HandleEquipMS"), onEquip)
 
 hook.Remove("PlayerDroppedWeapon", generateCFCHook("HandleDroppedWeaponMS"))
 hook.Add("PlayerDroppedWeapon", generateCFCHook("HandleDroppedWeaponMS"), onDrop)
-

--- a/lua/autorun/server/sv_pvp_movespeed.lua
+++ b/lua/autorun/server/sv_pvp_movespeed.lua
@@ -51,8 +51,10 @@ end
 
 local function setSpeed(ply, multiplier) 
     -- set speed multiplier, 0 - 1
-    ply:SetRunSpeed( math.Clamp( baseRunSpeed*multiplier, minRunSpeed, baseRunSpeed ) )
-    ply:SetWalkSpeed( math.Clamp( baseWalkSpeed*multiplier, minWalkSpeed, baseWalkSpeed ) )
+    local runSpeed = baseRunSpeed * multiplier
+    local walkSpeed = baseWalkSpeed * multiplier
+    ply:SetRunSpeed( math.Clamp( runSpeed, minRunSpeed, baseRunSpeed ) )
+    ply:SetWalkSpeed( math.Clamp( walkSpeed, minWalkSpeed, baseWalkSpeed ) )
 end
 
 local function adjustMovementSpeed( ply, wepNum ) 
@@ -79,7 +81,7 @@ end
 -- Hook Functions --
 local function onEquip( wep, ply )
     if not IsValid( ply ) then return end
-    wepNum = 0
+    local wepNum = 0
     if wep and nonEffectedWeapons[wep:GetClass()] == nil then
         wepNum = 1
     end
@@ -88,7 +90,7 @@ end
 
 local function onDrop( ply, wep )
     if not IsValid( ply ) then return end
-    wepNum = 0
+    local wepNum = 0
     if wep and nonEffectedWeapons[wep:GetClass()] == nil then
         wepNum = -1
     end

--- a/lua/autorun/server/sv_pvp_movespeed.lua
+++ b/lua/autorun/server/sv_pvp_movespeed.lua
@@ -65,7 +65,7 @@ local function adjustMovementSpeed(ply, wep)
     local wepCount = 0
     
     -- count weapons
-    if nonEffectedWeapons[wep:GetClass()] == nil then
+    if wep and nonEffectedWeapons[wep:GetClass()] == nil then
         wepCount =  wepCount+1
     end
     for k, weapon in pairs(weapons) do
@@ -79,15 +79,20 @@ local function adjustMovementSpeed(ply, wep)
 end
 
 -- Hook Functions --
-local function onEquipOrDrop( wep, ply )
+local function onEquip( wep, ply )
     if not IsValid( ply ) then return end
     adjustMovementSpeed( ply, wep )
 end
 
+local function onDrop( ply, wep )
+    if not IsValid( ply ) then return end
+    adjustMovementSpeed( ply, nil )
+end
+
 -- Hooks --
 hook.Remove("WeaponEquip", generateCFCHook("HandleEquipMS"))
-hook.Add("WeaponEquip", generateCFCHook("HandleEquipMS"), onEquipOrDrop)
+hook.Add("WeaponEquip", generateCFCHook("HandleEquipMS"), onEquip)
 
 hook.Remove("PlayerDroppedWeapon", generateCFCHook("HandleDroppedWeaponMS"))
-hook.Add("PlayerDroppedWeapon", generateCFCHook("HandleDroppedWeaponMS"), onEquipOrDrop)
+hook.Add("PlayerDroppedWeapon", generateCFCHook("HandleDroppedWeaponMS"), onDrop)
 

--- a/lua/autorun/server/sv_pvp_movespeed.lua
+++ b/lua/autorun/server/sv_pvp_movespeed.lua
@@ -60,10 +60,8 @@ end
 
 local function getWeaponWeight( weapon )
     -- the weight/significance of a weapon (1 for affecting weight 0 for not affecting weight)
-    if not nonEffectedWeapons[weapon:GetClass()] then
-        return 1
-    end
-    return 0
+    if nonEffectedWeapons[weapon:GetClass()] then return 0 end
+    return 1
 end
 
 local function getWeaponCount( ply ) 

--- a/lua/autorun/server/sv_pvp_movespeed.lua
+++ b/lua/autorun/server/sv_pvp_movespeed.lua
@@ -70,7 +70,7 @@ local function adjustMovementSpeed( ply, wepNum )
             wepCount =  wepCount + 1
         end
     end
-    wepCount = math.Clamp(wepCount + wepNum, 0, wepCount + wepNum)
+    wepCount = math.max(wepCount + wepNum, 0)
     
     local multiplier = movementMultiplier( wepCount ) 
     setSpeed(ply, multiplier)

--- a/lua/autorun/server/sv_pvp_movespeed.lua
+++ b/lua/autorun/server/sv_pvp_movespeed.lua
@@ -44,7 +44,8 @@ local function playerIsInBuild( ply )
     return !getPlayerPvpMode( ply )
 end
 
-local function movementMultiplier(weaponCount) 
+local function movementMultiplier(weaponCount)
+    if weaponCount < 1 then return 1 end
     return math.Clamp(1 - (1.9^( weaponCount))/100, 0, 1)
 end
 
@@ -75,12 +76,15 @@ local function adjustMovementSpeed(ply)
 end
 
 -- Hook Functions --
-local function onEquipped( wep, ply )
+local function onEquipOrDrop( wep, ply )
     if not IsValid( ply ) then return end
     adjustMovementSpeed( ply )
 end
 
 -- Hooks --
 hook.Remove("WeaponEquip", generateCFCHook("HandleEquipMS"))
-hook.Add("WeaponEquip", generateCFCHook("HandleEquipMS"), onEquipped)
+hook.Add("WeaponEquip", generateCFCHook("HandleEquipMS"), onEquipOrDrop)
+
+hook.Remove("PlayerDroppedWeapon", generateCFCHook("HandleDroppedWeaponMS"))
+hook.Add("PlayerDroppedWeapon", generateCFCHook("HandleDroppedWeaponMS"), onEquipOrDrop)
 


### PR DESCRIPTION
adds a check in movement multiplier 
adjustMovementSpeed now takes an argument weapon, this is because of an issue where the weapon that triggered the adjustment did not count towards the weight
added a hook PlayerDroppedWeapon (this fixes the issue with a /drop command not adjusting the speed)